### PR TITLE
Sanitize invalid characters before redirecting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - 10.15
+- 15
 
 cache:
   yarn: true

--- a/lib/escort.js
+++ b/lib/escort.js
@@ -66,6 +66,30 @@ var calculateConverterArgs, generateUrlFunction;
         ACCEPTABLE_METHOD_SET[method] = true;
     });
 
+    /**
+     * a regex which contains invalid characters
+     * @api private
+     */
+    var REGEXP_INVALID_CHARACTERS_REGEX = /[^\t\x20-\x7e\x80-\xff]/g;
+
+    /**
+     * URI encode a string if it contains invalid characters.
+     *
+     * @param {String} text The text to encode
+     * @return {String} The encoded text
+     * @api private
+     *
+     * @example regexpSanitize("Hello") == "Hello"
+     * @example regexpSanitize("/foo?mi_u=ƒoo\r\nbar") == "%C6%92oo%0D%0Abar"
+     */
+    var regexpSanitize = function (text) {
+        if (text.match(REGEXP_INVALID_CHARACTERS_REGEX)) {
+            return encodeURIComponent(String(text));
+        }
+
+        return String(text);
+    };
+
     var freeze = Object.freeze;
     /**
      * a simple wrapper around Object.create to easily make new objects without providing property descriptors.
@@ -380,7 +404,7 @@ var calculateConverterArgs, generateUrlFunction;
 
     var movedPermanently = function (response, location) {
         response.writeHead(301, {
-            "Location": location
+            "Location": regexpSanitize(location)
         });
         response.end("");
         return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/escort",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Routing and URL generation middleware",
   "keywords": [
     "framework",

--- a/test/escort.test.js
+++ b/test/escort.test.js
@@ -1272,6 +1272,20 @@ describe("escort", function() {
                           { statusCode: 301, headers: { Location: "/thing?hello=there" } });
   });
 
+  it("retrieving a known URL with invalid characters in querystring should return a MovedPermanently with scrubbed querystring", async function() {
+    var app = makeConnect(
+      escort(function (routes) {
+        routes.get("/thing", function (req, res) {
+          res.end("GET /thing");
+        });
+      })
+    );
+
+    await assert.response(app,
+                          { url: "/thing/?baz=%17693a9f-2e38-4a06-8b2f-1856f3d9908f%25", method: "GET" },
+                          { statusCode: 301, headers: { Location: "/thing?baz=%17693a9f-2e38-4a06-8b2f-1856f3d9908f%25" } });
+  });
+
   it("retrieving an unknown URL with a slash should return a NotFound", async function() {
     var app = makeConnect(
       escort(function (routes) {

--- a/test/escort.test.js
+++ b/test/escort.test.js
@@ -1274,7 +1274,6 @@ describe("escort", function() {
   });
 
   it("sanitizes bad redirects", async function () {
-    var url;
     var app = makeConnect(
       function (req, res, next) {
         req.url = req.originalUrl = "/route/?u=\u0016ee%";
@@ -1282,8 +1281,6 @@ describe("escort", function() {
         next();
       },
       escort(function (routes) {
-        url = routes.url;
-
         routes.get("route", "/route", function (req, res) {
           res.end("ok");
         });


### PR DESCRIPTION
[ch45525]

If a request triggers the `movedPermanently` method, e.g. by including a trailing slash where one is not expected, and the request includes query parameters with invalid characters, node will raise `TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Location"]`.  This change `URIEncode`s the redirect target before redirecting if it contains any invalid characters