### PR TITLE
encodeURI vs encodeURIComponent

### DIFF
--- a/lib/escort.js
+++ b/lib/escort.js
@@ -84,7 +84,7 @@ var calculateConverterArgs, generateUrlFunction;
      */
     var regexpSanitize = function (text) {
         if (text.match(REGEXP_INVALID_CHARACTERS_REGEX)) {
-            return encodeURIComponent(String(text));
+            return encodeURI(String(text));
         }
 
         return String(text);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/escort",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Routing and URL generation middleware",
   "keywords": [
     "framework",

--- a/test/escort.test.js
+++ b/test/escort.test.js
@@ -1287,7 +1287,7 @@ describe("escort", function() {
       })
     );
 
-    const expectedHeaders = { Location: "%2Froute%3Fu%3D%16ee%25" };
+    const expectedHeaders = { Location: "/route?u=%16ee%25" };
 
     await assert.response(
       app,


### PR DESCRIPTION
`regexpSanitize` should be using `encodeURI` instead of `encodeURIComponent`.  The former leaves URL structure, e.g. `https://` intact, whereas the latter encodes *everything*.

For example:
`encodeURI("http://example.com/path to file.txt")` => `http://example.com/path%20to%20file.txt"
`encodeURIComponent("http://example.com/path to file.txt")` => `http%3A%2F%2Fexample.com%2Fpath%20to%20file.txt`

ch45525