### PR TITLE
Gracefully handle encoded query params

### DIFF
--- a/lib/escort.js
+++ b/lib/escort.js
@@ -1182,7 +1182,11 @@ var calculateConverterArgs, generateUrlFunction;
                 try {
                     value = decodeURIComponent(value);
                 } catch(e) {
-                    throw new ValidationError();
+                    if (e instanceof URIError) {
+                        return value
+                    } else {
+                        throw new ValidationError();
+                    }
                 }
                 if (!this._allowNonASCII && !isASCII(value)) {
                     throw new ValidationError();

--- a/lib/escort.js
+++ b/lib/escort.js
@@ -1182,9 +1182,7 @@ var calculateConverterArgs, generateUrlFunction;
                 try {
                     value = decodeURIComponent(value);
                 } catch(e) {
-                    if (e instanceof URIError) {
-                        return value
-                    } else {
+                    if (!(e instanceof URIError)) {
                         throw new ValidationError();
                     }
                 }
@@ -1227,7 +1225,13 @@ var calculateConverterArgs, generateUrlFunction;
             regex: "[^/]+(?:/[^/]+)*",
             weight: 50,
             fromUrl: function (value) {
-                value = decodeURIComponent(value);
+                try {
+                    value = decodeURIComponent(value);
+                } catch(e) {
+                    if (!(e instanceof URIError)) {
+                        throw new ValidationError();
+                    }
+                }
                 if (!this._allowNonASCII && !isASCII(value)) {
                     throw new ValidationError();
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/escort",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Routing and URL generation middleware",
   "keywords": [
     "framework",

--- a/test/escort.test.js
+++ b/test/escort.test.js
@@ -1369,6 +1369,10 @@ describe("escort", function() {
       await assert.response(app,
                             { url: "/THING/" + name + "/BLAH", method: "GET" },
                             { statusCode: 301, headers: { Location: "/Thing/" + name + "/Blah" } });
+
+      await assert.response(app,
+                            { url: "/Thing/" + name + "%3FBlah%3D%25" },
+                            { statusCode: 301, headers: { Location: "/Thing/" + name + "?blah=%"}})
     }
   });
 

--- a/test/escort.test.js
+++ b/test/escort.test.js
@@ -1369,10 +1369,6 @@ describe("escort", function() {
       await assert.response(app,
                             { url: "/THING/" + name + "/BLAH", method: "GET" },
                             { statusCode: 301, headers: { Location: "/Thing/" + name + "/Blah" } });
-
-      await assert.response(app,
-                            { url: "/Thing/" + name + "%3FBlah%3D%25" },
-                            { statusCode: 301, headers: { Location: "/Thing/" + name + "?blah=%"}})
     }
   });
 
@@ -1479,6 +1475,54 @@ describe("escort", function() {
       await assert.response(app,
                             { url: "/bravo/" + name.toUpperCase(), method: "GET" },
                             { body: "GET /bravo/" + name.toUpperCase() });
+    }
+  });
+
+  it("string converter with encoded query params", async function() {
+    var app = makeConnect(
+      escort(function (routes) {
+        routes.get("alpha", "/alpha/{item:string}", function(req, res, params) {
+          res.end("GET /alpha/" + params.item);
+        });
+
+        routes.get("bravo", "/bravo/{item:string({allowUpperCase: true})}", function(req, res, params) {
+          res.end("GET /bravo/" + params.item);
+        });
+      })
+    );
+
+    for (let name of exampleNames) {
+      await assert.response(app,
+                            { url: "/alpha/" + name + encodeURIComponent("?Blah=%") },
+                            { statusCode: 301, headers: { Location: "/alpha/" + name + "?blah=%" } });
+
+      await assert.response(app,
+                            { url: "/bravo/" + name + encodeURIComponent("?Blah=%") },
+                            { body: "GET /bravo/" + name + "?Blah=%" });
+    }
+  });
+
+  it("path converter with encoded query params", async function() {
+    var app = makeConnect(
+      escort(function (routes) {
+        routes.get("alpha", "/alpha/{item:path}", function(req, res, params) {
+          res.end("GET /alpha/" + params.item);
+        });
+
+        routes.get("bravo", "/bravo/{item:path({allowUpperCase: true})}", function(req, res, params) {
+          res.end("GET /bravo/" + params.item);
+        });
+      })
+    );
+
+    for (let name of exampleNames) {
+      await assert.response(app,
+                            { url: "/alpha/" + name + encodeURIComponent("?Blah=%") },
+                            { statusCode: 301, headers: { Location: "/alpha/" + name + "?blah=%" } });
+
+      await assert.response(app,
+                            { url: "/bravo/" + name + encodeURIComponent("?Blah=%") },
+                            { body: "GET /bravo/" + name + "?Blah=%" });
     }
   });
 


### PR DESCRIPTION
Gracefully handle fully encoded query params (including the `?`) when case sensitive

[ch46043]